### PR TITLE
Fix partition demo typing for Python 3.9

### DIFF
--- a/scripts/chem/partition_demo.py
+++ b/scripts/chem/partition_demo.py
@@ -331,7 +331,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: List[str] | None = None) -> int:
+def main(argv: Optional[List[str]] = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     mol = Chem.MolFromSmiles(args.smiles)
     if mol is None:


### PR DESCRIPTION
## Summary
- replace the PEP 604 union annotation in the partition demo CLI entry point with Optional[List[str]] to remain compatible with Python 3.9

## Testing
- python scripts/chem/partition_demo.py "Cc1ccccc1" --partitions 2 --seed 2 *(fails: ModuleNotFoundError: No module named 'rdkit')*


------
https://chatgpt.com/codex/tasks/task_e_68dbc2ba538483259500a39731068235